### PR TITLE
Import getPresetChars and PRESET_INFO from presets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import fg from 'fast-glob'
 import fs from 'fs'
 import path from 'path'
 import { subsetFont } from './core/subsetFont.js'
+import { getPresetChars, PRESET_INFO } from './presets/index.js'
 
 export default function fontSubsetPlugin(options = {}) {
 	const {


### PR DESCRIPTION
修复使用`preset`选项后，报`getPresetChars `和`PRESET_INFO ` 未定义的问题